### PR TITLE
Rename MediaSessionConnection to MusicServiceConnection

### DIFF
--- a/app/src/main/java/com/example/android/uamp/utils/InjectorUtils.kt
+++ b/app/src/main/java/com/example/android/uamp/utils/InjectorUtils.kt
@@ -19,7 +19,7 @@ package com.example.android.uamp.utils
 import android.app.Application
 import android.content.ComponentName
 import android.content.Context
-import com.example.android.uamp.common.MediaSessionConnection
+import com.example.android.uamp.common.MusicServiceConnection
 import com.example.android.uamp.media.MusicService
 import com.example.android.uamp.viewmodels.MainActivityViewModel
 import com.example.android.uamp.viewmodels.MediaItemFragmentViewModel
@@ -29,29 +29,29 @@ import com.example.android.uamp.viewmodels.NowPlayingFragmentViewModel
  * Static methods used to inject classes needed for various Activities and Fragments.
  */
 object InjectorUtils {
-    private fun provideMediaSessionConnection(context: Context): MediaSessionConnection {
-        return MediaSessionConnection.getInstance(context,
+    private fun provideMusicServiceConnection(context: Context): MusicServiceConnection {
+        return MusicServiceConnection.getInstance(context,
                 ComponentName(context, MusicService::class.java))
     }
 
     fun provideMainActivityViewModel(context: Context): MainActivityViewModel.Factory {
         val applicationContext = context.applicationContext
-        val mediaSessionConnection = provideMediaSessionConnection(applicationContext)
-        return MainActivityViewModel.Factory(mediaSessionConnection)
+        val musicServiceConnection = provideMusicServiceConnection(applicationContext)
+        return MainActivityViewModel.Factory(musicServiceConnection)
     }
 
     fun provideMediaItemFragmentViewModel(context: Context, mediaId: String)
             : MediaItemFragmentViewModel.Factory {
         val applicationContext = context.applicationContext
-        val mediaSessionConnection = provideMediaSessionConnection(applicationContext)
-        return MediaItemFragmentViewModel.Factory(mediaId, mediaSessionConnection)
+        val musicServiceConnection = provideMusicServiceConnection(applicationContext)
+        return MediaItemFragmentViewModel.Factory(mediaId, musicServiceConnection)
     }
 
     fun provideNowPlayingFragmentViewModel(context: Context)
             : NowPlayingFragmentViewModel.Factory {
         val applicationContext = context.applicationContext
-        val mediaSessionConnection = provideMediaSessionConnection(applicationContext)
+        val musicServiceConnection = provideMusicServiceConnection(applicationContext)
         return NowPlayingFragmentViewModel.Factory(
-                applicationContext as Application, mediaSessionConnection)
+                applicationContext as Application, musicServiceConnection)
     }
 }

--- a/app/src/main/java/com/example/android/uamp/viewmodels/MainActivityViewModel.kt
+++ b/app/src/main/java/com/example/android/uamp/viewmodels/MainActivityViewModel.kt
@@ -27,7 +27,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import com.example.android.uamp.MainActivity
 import com.example.android.uamp.MediaItemData
-import com.example.android.uamp.common.MediaSessionConnection
+import com.example.android.uamp.common.MusicServiceConnection
 import com.example.android.uamp.fragments.NowPlayingFragment
 import com.example.android.uamp.media.extensions.id
 import com.example.android.uamp.media.extensions.isPlayEnabled
@@ -36,17 +36,17 @@ import com.example.android.uamp.media.extensions.isPrepared
 import com.example.android.uamp.utils.Event
 
 /**
- * Small [ViewModel] that watches a [MediaSessionConnection] to become connected
+ * Small [ViewModel] that watches a [MusicServiceConnection] to become connected
  * and provides the root/initial media ID of the underlying [MediaBrowserCompat].
  */
 class MainActivityViewModel(
-    private val mediaSessionConnection: MediaSessionConnection
+    private val musicServiceConnection: MusicServiceConnection
 ) : ViewModel() {
 
     val rootMediaId: LiveData<String> =
-        Transformations.map(mediaSessionConnection.isConnected) { isConnected ->
+        Transformations.map(musicServiceConnection.isConnected) { isConnected ->
             if (isConnected) {
-                mediaSessionConnection.rootMediaId
+                musicServiceConnection.rootMediaId
             } else {
                 null
             }
@@ -113,12 +113,12 @@ class MainActivityViewModel(
      *   then pause playback, otherwise send "play" to resume playback.
      */
     fun playMedia(mediaItem: MediaItemData, pauseAllowed: Boolean = true) {
-        val nowPlaying = mediaSessionConnection.nowPlaying.value
-        val transportControls = mediaSessionConnection.transportControls
+        val nowPlaying = musicServiceConnection.nowPlaying.value
+        val transportControls = musicServiceConnection.transportControls
 
-        val isPrepared = mediaSessionConnection.playbackState.value?.isPrepared ?: false
+        val isPrepared = musicServiceConnection.playbackState.value?.isPrepared ?: false
         if (isPrepared && mediaItem.mediaId == nowPlaying?.id) {
-            mediaSessionConnection.playbackState.value?.let { playbackState ->
+            musicServiceConnection.playbackState.value?.let { playbackState ->
                 when {
                     playbackState.isPlaying ->
                         if (pauseAllowed) transportControls.pause() else Unit
@@ -137,12 +137,12 @@ class MainActivityViewModel(
     }
 
     fun playMediaId(mediaId: String) {
-        val nowPlaying = mediaSessionConnection.nowPlaying.value
-        val transportControls = mediaSessionConnection.transportControls
+        val nowPlaying = musicServiceConnection.nowPlaying.value
+        val transportControls = musicServiceConnection.transportControls
 
-        val isPrepared = mediaSessionConnection.playbackState.value?.isPrepared ?: false
+        val isPrepared = musicServiceConnection.playbackState.value?.isPrepared ?: false
         if (isPrepared && mediaId == nowPlaying?.id) {
-            mediaSessionConnection.playbackState.value?.let { playbackState ->
+            musicServiceConnection.playbackState.value?.let { playbackState ->
                 when {
                     playbackState.isPlaying -> transportControls.pause()
                     playbackState.isPlayEnabled -> transportControls.play()
@@ -160,12 +160,12 @@ class MainActivityViewModel(
     }
 
     class Factory(
-        private val mediaSessionConnection: MediaSessionConnection
+        private val musicServiceConnection: MusicServiceConnection
     ) : ViewModelProvider.NewInstanceFactory() {
 
         @Suppress("unchecked_cast")
         override fun <T : ViewModel?> create(modelClass: Class<T>): T {
-            return MainActivityViewModel(mediaSessionConnection) as T
+            return MainActivityViewModel(musicServiceConnection) as T
         }
     }
 }

--- a/app/src/main/java/com/example/android/uamp/viewmodels/MediaItemFragmentViewModel.kt
+++ b/app/src/main/java/com/example/android/uamp/viewmodels/MediaItemFragmentViewModel.kt
@@ -30,7 +30,7 @@ import androidx.lifecycle.ViewModelProvider
 import com.example.android.uamp.MediaItemData
 import com.example.android.uamp.R
 import com.example.android.uamp.common.EMPTY_PLAYBACK_STATE
-import com.example.android.uamp.common.MediaSessionConnection
+import com.example.android.uamp.common.MusicServiceConnection
 import com.example.android.uamp.common.NOTHING_PLAYING
 import com.example.android.uamp.fragments.MediaItemFragment
 import com.example.android.uamp.media.extensions.id
@@ -40,8 +40,8 @@ import com.example.android.uamp.media.extensions.isPlaying
  * [ViewModel] for [MediaItemFragment].
  */
 class MediaItemFragmentViewModel(
-    private val mediaId: String,
-    mediaSessionConnection: MediaSessionConnection
+        private val mediaId: String,
+        musicServiceConnection: MusicServiceConnection
 ) : ViewModel() {
 
     /**
@@ -52,9 +52,9 @@ class MediaItemFragmentViewModel(
     val mediaItems: LiveData<List<MediaItemData>> = _mediaItems
 
     /**
-     * Pass the status of the [MediaSessionConnection.networkFailure] through.
+     * Pass the status of the [MusicServiceConnection.networkFailure] through.
      */
-    val networkError = Transformations.map(mediaSessionConnection.networkFailure) { it }
+    val networkError = Transformations.map(musicServiceConnection.networkFailure) { it }
 
     private val subscriptionCallback = object : SubscriptionCallback() {
         override fun onChildrenLoaded(parentId: String, children: List<MediaItem>) {
@@ -80,7 +80,7 @@ class MediaItemFragmentViewModel(
      */
     private val playbackStateObserver = Observer<PlaybackStateCompat> {
         val playbackState = it ?: EMPTY_PLAYBACK_STATE
-        val metadata = mediaSessionConnection.nowPlaying.value ?: NOTHING_PLAYING
+        val metadata = musicServiceConnection.nowPlaying.value ?: NOTHING_PLAYING
         if (metadata.getString(MediaMetadataCompat.METADATA_KEY_MEDIA_ID) != null) {
             _mediaItems.postValue(updateState(playbackState, metadata))
         }
@@ -93,7 +93,7 @@ class MediaItemFragmentViewModel(
      * changed. (i.e.: play/pause button or blank)
      */
     private val mediaMetadataObserver = Observer<MediaMetadataCompat> {
-        val playbackState = mediaSessionConnection.playbackState.value ?: EMPTY_PLAYBACK_STATE
+        val playbackState = musicServiceConnection.playbackState.value ?: EMPTY_PLAYBACK_STATE
         val metadata = it ?: NOTHING_PLAYING
         if (metadata.getString(MediaMetadataCompat.METADATA_KEY_MEDIA_ID) != null) {
             _mediaItems.postValue(updateState(playbackState, metadata))
@@ -101,7 +101,7 @@ class MediaItemFragmentViewModel(
     }
 
     /**
-     * Because there's a complex dance between this [ViewModel] and the [MediaSessionConnection]
+     * Because there's a complex dance between this [ViewModel] and the [MusicServiceConnection]
      * (which is wrapping a [MediaBrowserCompat] object), the usual guidance of using
      * [Transformations] doesn't quite work.
      *
@@ -111,13 +111,13 @@ class MediaItemFragmentViewModel(
      * [subscriptionCallback] (defined above) is called if/when the children of this
      * ViewModel's [mediaId] changes.
      *
-     * [MediaSessionConnection.playbackState] changes state based on the playback state of
+     * [MusicServiceConnection.playbackState] changes state based on the playback state of
      * the player, which can change the [MediaItemData.playbackRes]s in the list.
      *
-     * [MediaSessionConnection.nowPlaying] changes based on the item that's being played,
+     * [MusicServiceConnection.nowPlaying] changes based on the item that's being played,
      * which can also change the [MediaItemData.playbackRes]s in the list.
      */
-    private val mediaSessionConnection = mediaSessionConnection.also {
+    private val musicServiceConnection = musicServiceConnection.also {
         it.subscribe(mediaId, subscriptionCallback)
 
         it.playbackState.observeForever(playbackStateObserver)
@@ -125,26 +125,26 @@ class MediaItemFragmentViewModel(
     }
 
     /**
-     * Since we use [LiveData.observeForever] above (in [mediaSessionConnection]), we want
+     * Since we use [LiveData.observeForever] above (in [musicServiceConnection]), we want
      * to call [LiveData.removeObserver] here to prevent leaking resources when the [ViewModel]
      * is not longer in use.
      *
-     * For more details, see the kdoc on [mediaSessionConnection] above.
+     * For more details, see the kdoc on [musicServiceConnection] above.
      */
     override fun onCleared() {
         super.onCleared()
 
-        // Remove the permanent observers from the MediaSessionConnection.
-        mediaSessionConnection.playbackState.removeObserver(playbackStateObserver)
-        mediaSessionConnection.nowPlaying.removeObserver(mediaMetadataObserver)
+        // Remove the permanent observers from the MusicServiceConnection.
+        musicServiceConnection.playbackState.removeObserver(playbackStateObserver)
+        musicServiceConnection.nowPlaying.removeObserver(mediaMetadataObserver)
 
         // And then, finally, unsubscribe the media ID that was being watched.
-        mediaSessionConnection.unsubscribe(mediaId, subscriptionCallback)
+        musicServiceConnection.unsubscribe(mediaId, subscriptionCallback)
     }
 
     private fun getResourceForMediaId(mediaId: String): Int {
-        val isActive = mediaId == mediaSessionConnection.nowPlaying.value?.id
-        val isPlaying = mediaSessionConnection.playbackState.value?.isPlaying ?: false
+        val isActive = mediaId == musicServiceConnection.nowPlaying.value?.id
+        val isPlaying = musicServiceConnection.playbackState.value?.isPlaying ?: false
         return when {
             !isActive -> NO_RES
             isPlaying -> R.drawable.ic_pause_black_24dp
@@ -170,12 +170,12 @@ class MediaItemFragmentViewModel(
 
     class Factory(
         private val mediaId: String,
-        private val mediaSessionConnection: MediaSessionConnection
+        private val musicServiceConnection: MusicServiceConnection
     ) : ViewModelProvider.NewInstanceFactory() {
 
         @Suppress("unchecked_cast")
         override fun <T : ViewModel?> create(modelClass: Class<T>): T {
-            return MediaItemFragmentViewModel(mediaId, mediaSessionConnection) as T
+            return MediaItemFragmentViewModel(mediaId, musicServiceConnection) as T
         }
     }
 }

--- a/app/src/main/java/com/example/android/uamp/viewmodels/NowPlayingFragmentViewModel.kt
+++ b/app/src/main/java/com/example/android/uamp/viewmodels/NowPlayingFragmentViewModel.kt
@@ -31,7 +31,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import com.example.android.uamp.R
 import com.example.android.uamp.common.EMPTY_PLAYBACK_STATE
-import com.example.android.uamp.common.MediaSessionConnection
+import com.example.android.uamp.common.MusicServiceConnection
 import com.example.android.uamp.common.NOTHING_PLAYING
 import com.example.android.uamp.fragments.NowPlayingFragment
 import com.example.android.uamp.media.extensions.albumArtUri
@@ -48,8 +48,8 @@ import com.example.android.uamp.media.extensions.title
  * resources.
  */
 class NowPlayingFragmentViewModel(
-    private val app: Application,
-    mediaSessionConnection: MediaSessionConnection
+        private val app: Application,
+        musicServiceConnection: MusicServiceConnection
 ) : AndroidViewModel(app) {
 
     /**
@@ -97,7 +97,7 @@ class NowPlayingFragmentViewModel(
      */
     private val playbackStateObserver = Observer<PlaybackStateCompat> {
         playbackState = it ?: EMPTY_PLAYBACK_STATE
-        val metadata = mediaSessionConnection.nowPlaying.value ?: NOTHING_PLAYING
+        val metadata = musicServiceConnection.nowPlaying.value ?: NOTHING_PLAYING
         updateState(playbackState, metadata)
     }
 
@@ -112,20 +112,20 @@ class NowPlayingFragmentViewModel(
     }
 
     /**
-     * Because there's a complex dance between this [ViewModel] and the [MediaSessionConnection]
+     * Because there's a complex dance between this [ViewModel] and the [MusicServiceConnection]
      * (which is wrapping a [MediaBrowserCompat] object), the usual guidance of using
      * [Transformations] doesn't quite work.
      *
      * Specifically there's three things that are watched that will cause the single piece of
      * [LiveData] exposed from this class to be updated.
      *
-     * [MediaSessionConnection.playbackState] changes state based on the playback state of
+     * [MusicServiceConnection.playbackState] changes state based on the playback state of
      * the player, which can change the [MediaItemData.playbackRes]s in the list.
      *
-     * [MediaSessionConnection.nowPlaying] changes based on the item that's being played,
+     * [MusicServiceConnection.nowPlaying] changes based on the item that's being played,
      * which can also change the [MediaItemData.playbackRes]s in the list.
      */
-    private val mediaSessionConnection = mediaSessionConnection.also {
+    private val musicServiceConnection = musicServiceConnection.also {
         it.playbackState.observeForever(playbackStateObserver)
         it.nowPlaying.observeForever(mediaMetadataObserver)
         checkPlaybackPosition()
@@ -145,18 +145,18 @@ class NowPlayingFragmentViewModel(
     }, POSITION_UPDATE_INTERVAL_MILLIS)
 
     /**
-     * Since we use [LiveData.observeForever] above (in [mediaSessionConnection]), we want
+     * Since we use [LiveData.observeForever] above (in [musicServiceConnection]), we want
      * to call [LiveData.removeObserver] here to prevent leaking resources when the [ViewModel]
      * is not longer in use.
      *
-     * For more details, see the kdoc on [mediaSessionConnection] above.
+     * For more details, see the kdoc on [musicServiceConnection] above.
      */
     override fun onCleared() {
         super.onCleared()
 
-        // Remove the permanent observers from the MediaSessionConnection.
-        mediaSessionConnection.playbackState.removeObserver(playbackStateObserver)
-        mediaSessionConnection.nowPlaying.removeObserver(mediaMetadataObserver)
+        // Remove the permanent observers from the MusicServiceConnection.
+        musicServiceConnection.playbackState.removeObserver(playbackStateObserver)
+        musicServiceConnection.nowPlaying.removeObserver(mediaMetadataObserver)
 
         // Stop updating the position
         updatePosition = false
@@ -190,12 +190,12 @@ class NowPlayingFragmentViewModel(
 
     class Factory(
         private val app: Application,
-        private val mediaSessionConnection: MediaSessionConnection
+        private val musicServiceConnection: MusicServiceConnection
     ) : ViewModelProvider.NewInstanceFactory() {
 
         @Suppress("unchecked_cast")
         override fun <T : ViewModel?> create(modelClass: Class<T>): T {
-            return NowPlayingFragmentViewModel(app, mediaSessionConnection) as T
+            return NowPlayingFragmentViewModel(app, musicServiceConnection) as T
         }
     }
 }

--- a/automotive/src/main/java/com/example/android/uamp/automotive/SettingsFragment.kt
+++ b/automotive/src/main/java/com/example/android/uamp/automotive/SettingsFragment.kt
@@ -23,7 +23,7 @@ import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.ViewModelProviders
 import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
-import com.example.android.uamp.common.MediaSessionConnection
+import com.example.android.uamp.common.MusicServiceConnection
 
 /**
  * Preference fragment hosted by [SettingsActivity]. Handles events to various preference changes.
@@ -58,13 +58,13 @@ class SettingsFragment : PreferenceFragmentCompat() {
  */
 class SettingsFragmentViewModel(application: Application) : AndroidViewModel(application) {
     private val applicationContext = application.applicationContext
-    private val mediaSessionConnection = MediaSessionConnection(
+    private val musicServiceConnection = MusicServiceConnection(
         applicationContext,
         ComponentName(applicationContext, AutomotiveMusicService::class.java)
     )
 
     fun logout() {
         // Logout is fire and forget.
-        mediaSessionConnection.sendCommand(LOGOUT, null)
+        musicServiceConnection.sendCommand(LOGOUT, null)
     }
 }

--- a/automotive/src/main/java/com/example/android/uamp/automotive/SignInActivityViewModel.kt
+++ b/automotive/src/main/java/com/example/android/uamp/automotive/SignInActivityViewModel.kt
@@ -25,7 +25,7 @@ import android.widget.Toast
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
-import com.example.android.uamp.common.MediaSessionConnection
+import com.example.android.uamp.common.MusicServiceConnection
 import java.util.Random
 
 /**
@@ -33,7 +33,7 @@ import java.util.Random
  */
 class SignInActivityViewModel(application: Application) : AndroidViewModel(application) {
     private val applicationContext = application.applicationContext
-    private val mediaSessionConnection = MediaSessionConnection(
+    private val musicServiceConnection = MusicServiceConnection(
             applicationContext,
             ComponentName(applicationContext, AutomotiveMusicService::class.java)
     )
@@ -53,7 +53,7 @@ class SignInActivityViewModel(application: Application) : AndroidViewModel(appli
                 putString(LOGIN_EMAIL, email)
                 putString(LOGIN_PASSWORD, password)
             }
-            mediaSessionConnection.sendCommand(LOGIN, loginParams) { resultCode, _ ->
+            musicServiceConnection.sendCommand(LOGIN, loginParams) { resultCode, _ ->
                 _loggedIn.postValue(resultCode == Activity.RESULT_OK)
             }
         }

--- a/common/src/main/java/com/example/android/uamp/common/MusicServiceConnection.kt
+++ b/common/src/main/java/com/example/android/uamp/common/MusicServiceConnection.kt
@@ -28,11 +28,12 @@ import android.support.v4.media.session.MediaSessionCompat
 import android.support.v4.media.session.PlaybackStateCompat
 import androidx.lifecycle.MutableLiveData
 import androidx.media.MediaBrowserServiceCompat
-import com.example.android.uamp.common.MediaSessionConnection.MediaBrowserConnectionCallback
+import com.example.android.uamp.common.MusicServiceConnection.MediaBrowserConnectionCallback
 import com.example.android.uamp.media.NETWORK_FAILURE
 
 /**
- * Class that manages a connection to a [MediaBrowserServiceCompat] instance.
+ * Class that manages a connection to a [MediaBrowserServiceCompat] instance, typically a
+ * [MusicService] or one of its subclasses.
  *
  * Typically it's best to construct/inject dependencies either using DI or, as UAMP does,
  * using [InjectorUtils] in the app module. There are a few difficulties for that here:
@@ -45,11 +46,11 @@ import com.example.android.uamp.media.NETWORK_FAILURE
  *  Because of these reasons, rather than constructing additional classes, this is treated as
  *  a black box (which is why there's very little logic here).
  *
- *  This is also why the parameters to construct a [MediaSessionConnection] are simple
+ *  This is also why the parameters to construct a [MusicServiceConnection] are simple
  *  parameters, rather than private properties. They're only required to build the
  *  [MediaBrowserConnectionCallback] and [MediaBrowserCompat] objects.
  */
-class MediaSessionConnection(context: Context, serviceComponent: ComponentName) {
+class MusicServiceConnection(context: Context, serviceComponent: ComponentName) {
     val isConnected = MutableLiveData<Boolean>()
         .apply { postValue(false) }
     val networkFailure = MutableLiveData<Boolean>()
@@ -163,11 +164,11 @@ class MediaSessionConnection(context: Context, serviceComponent: ComponentName) 
     companion object {
         // For Singleton instantiation.
         @Volatile
-        private var instance: MediaSessionConnection? = null
+        private var instance: MusicServiceConnection? = null
 
         fun getInstance(context: Context, serviceComponent: ComponentName) =
             instance ?: synchronized(this) {
-                instance ?: MediaSessionConnection(context, serviceComponent)
+                instance ?: MusicServiceConnection(context, serviceComponent)
                     .also { instance = it }
             }
     }
@@ -183,4 +184,3 @@ val NOTHING_PLAYING: MediaMetadataCompat = MediaMetadataCompat.Builder()
     .putString(MediaMetadataCompat.METADATA_KEY_MEDIA_ID, "")
     .putLong(MediaMetadataCompat.METADATA_KEY_DURATION, 0)
     .build()
-


### PR DESCRIPTION
I've renamed `MediaSessionConnection` to `MusicServiceConnection`. Here's why: 

- `MediaSessionConnection` is confusingly close to `MediaSessionConnector` which is provided by the MediaSession extension for ExoPlayer. 
- It's not actually a media session connection, it's a wrapper for both media browser and the media session. 
- The only classes it ever connects to are UAMP's `MusicService` class and its subclasses. Theoretically it could connect to another MediaBrowserService but this is unlikely given the nature of the sample.  

