### PR TITLE
Add cast support

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -60,6 +60,18 @@ dependencies {
     implementation "androidx.constraintlayout:constraintlayout:$constraint_layout_version"
     implementation "androidx.lifecycle:lifecycle-extensions:$arch_lifecycle_version"
 
+    // ExoPlayer dependencies
+
+    // This allows UAMP to utilize a local version of ExoPlayer, which is particularly
+    // useful for extending the MediaSession extension, as well as for testing and
+    // customization. If the ":exoplayer-library-core" project is included, we assume
+    // the others are included as well.
+    if (findProject(':exoplayer-library-core') != null) {
+        api project(':exoplayer-extension-cast')
+    } else {
+        api "com.google.android.exoplayer:extension-cast:$exoplayer_version"
+    }
+
     // Glide dependencies
     implementation "com.github.bumptech.glide:glide:$glide_version"
     kapt "com.github.bumptech.glide:compiler:$glide_version"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -38,6 +38,9 @@ android {
             useSupportLibrary true
         }
     }
+    kotlinOptions {
+        freeCompilerArgs = ["-Xallow-result-return-type"]
+    }
     dataBinding {
         enabled = true
     }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -63,18 +63,6 @@ dependencies {
     implementation "androidx.constraintlayout:constraintlayout:$constraint_layout_version"
     implementation "androidx.lifecycle:lifecycle-extensions:$arch_lifecycle_version"
 
-    // ExoPlayer dependencies
-
-    // This allows UAMP to utilize a local version of ExoPlayer, which is particularly
-    // useful for extending the MediaSession extension, as well as for testing and
-    // customization. If the ":exoplayer-library-core" project is included, we assume
-    // the others are included as well.
-    if (findProject(':exoplayer-library-core') != null) {
-        api project(':exoplayer-extension-cast')
-    } else {
-        api "com.google.android.exoplayer:extension-cast:$exoplayer_version"
-    }
-
     // Glide dependencies
     implementation "com.github.bumptech.glide:glide:$glide_version"
     kapt "com.github.bumptech.glide:compiler:$glide_version"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -36,6 +36,10 @@
             android:name="com.google.android.gms.car.application"
             android:resource="@xml/automotive_app_desc" />
 
+        <!-- Declare that UAMP supports Cast, using the default receiver. -->
+        <meta-data android:name="com.google.android.gms.cast.framework.OPTIONS_PROVIDER_CLASS_NAME"
+            android:value="com.google.android.exoplayer2.ext.cast.DefaultCastOptionsProvider"/>
+
         <activity android:name=".MainActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/java/com/example/android/uamp/MainActivity.kt
+++ b/app/src/main/java/com/example/android/uamp/MainActivity.kt
@@ -18,6 +18,7 @@ package com.example.android.uamp
 
 import android.media.AudioManager
 import android.os.Bundle
+import android.view.Menu
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProviders
@@ -26,6 +27,7 @@ import com.example.android.uamp.media.MusicService
 import com.example.android.uamp.utils.Event
 import com.example.android.uamp.utils.InjectorUtils
 import com.example.android.uamp.viewmodels.MainActivityViewModel
+import com.google.android.gms.cast.framework.CastButtonFactory
 import com.google.android.gms.cast.framework.CastContext
 import com.google.android.gms.dynamite.DynamiteModule
 
@@ -119,5 +121,12 @@ class MainActivity : AppCompatActivity() {
 
     private fun getBrowseFragment(mediaId: String): MediaItemFragment? {
         return supportFragmentManager.findFragmentByTag(mediaId) as MediaItemFragment?
+    }
+
+    override fun onCreateOptionsMenu(menu: Menu): Boolean {
+        super.onCreateOptionsMenu(menu)
+        menuInflater.inflate(R.menu.cast, menu)
+        CastButtonFactory.setUpMediaRouteButton(this, menu, R.id.media_route_menu_item)
+        return true
     }
 }

--- a/app/src/main/res/layout/cast_context_error.xml
+++ b/app/src/main/res/layout/cast_context_error.xml
@@ -14,18 +14,10 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<resources>
-    <string name="app_name">UAMP</string>
-
-    <string name="skip_back_10s">Skip back 10s</string>
-    <string name="skip_forward_10s">Skip forward 10s</string>
-    <string name="play">Play</string>
-    <string name="pause">Pause</string>
-
-    <string name="menu_music_queue">Queue</string>
-    <string name="album_art_alt">Album art</string>
-    <string name="duration_unknown">--:--</string>
-    <string name="duration_format">%d:%02d</string>
-
-    <string name="cast_context_error">Failed to get Cast context. Try updating Google Play Services and restart the app.</string>
-</resources>
+<TextView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/textView"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:gravity="center"
+    android:textSize="20sp"
+    android:text="@string/cast_context_error"/>

--- a/app/src/main/res/menu/cast.xml
+++ b/app/src/main/res/menu/cast.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+    <item
+        android:id="@+id/media_route_menu_item"
+        android:title="@string/cast"
+        app:actionProviderClass="androidx.mediarouter.app.MediaRouteActionProvider"
+        app:showAsAction="always" />
+</menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -27,5 +27,6 @@
     <string name="duration_unknown">--:--</string>
     <string name="duration_format">%d:%02d</string>
 
+    <string name="cast">Cast</string>
     <string name="cast_context_error">Failed to get Cast context. Try updating Google Play Services and restart the app.</string>
 </resources>

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -54,6 +54,8 @@ dependencies {
 
     api "com.google.code.gson:gson:$gson_version"
 
+    api "com.android.support:mediarouter-v7:28.0.0"
+
     // ExoPlayer dependencies
 
     // This allows UAMP to utilize a local version of ExoPlayer, which is particularly

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -66,10 +66,12 @@ dependencies {
         api project(':exoplayer-library-core')
         api project(':exoplayer-library-ui')
         api project(':exoplayer-extension-mediasession')
+        api project(':exoplayer-extension-cast')
     } else {
         api "com.google.android.exoplayer:exoplayer-core:$exoplayer_version"
         api "com.google.android.exoplayer:exoplayer-ui:$exoplayer_version"
         api "com.google.android.exoplayer:extension-mediasession:$exoplayer_version"
+        api "com.google.android.exoplayer:extension-cast:$exoplayer_version"
     }
 
     // Glide dependencies

--- a/common/src/main/java/com/example/android/uamp/media/MusicService.kt
+++ b/common/src/main/java/com/example/android/uamp/media/MusicService.kt
@@ -273,29 +273,6 @@ open class MusicService : MediaBrowserServiceCompat(), SessionAvailabilityListen
             currentPlayer.playWhenReady = playWhenReady
         }
     }
-
-    private fun MediaMetadataCompat.toMediaQueueItem(): MediaQueueItem {
-        val metadata: MediaMetadata = toCastMediaMetadata()
-        val mediaInfo = MediaInfo.Builder(this.mediaUri.toString())
-                .setStreamType(MediaInfo.STREAM_TYPE_BUFFERED)
-                .setContentType(MimeTypes.AUDIO_MPEG)
-                .setStreamDuration(this.duration)
-                .setMetadata(metadata)
-                .build()
-        return MediaQueueItem.Builder(mediaInfo).build()
-    }
-
-    private fun MediaMetadataCompat.toCastMediaMetadata(): MediaMetadata {
-        val mediaMetadata = MediaMetadata(MediaMetadata.MEDIA_TYPE_MUSIC_TRACK)
-        mediaMetadata.putString(MediaMetadata.KEY_TITLE, this.title)
-        mediaMetadata.putString(MediaMetadata.KEY_ARTIST, this.artist)
-        mediaMetadata.putString(MediaMetadata.KEY_ALBUM_TITLE, this.album)
-        mediaMetadata.putString(MediaMetadata.KEY_ALBUM_ARTIST, this.albumArtist)
-        mediaMetadata.putString(MediaMetadata.KEY_COMPOSER, this.composer)
-        this.date?.let { date -> mediaMetadata.putString(MediaMetadata.KEY_RELEASE_DATE, date) }
-        mediaMetadata.putInt(MediaMetadata.KEY_TRACK_NUMBER, this.trackNumber.toInt())
-        mediaMetadata.putInt(MediaMetadata.KEY_DISC_NUMBER, this.discNumber.toInt())
-        return mediaMetadata
     }
 
     /**

--- a/common/src/main/java/com/example/android/uamp/media/MusicService.kt
+++ b/common/src/main/java/com/example/android/uamp/media/MusicService.kt
@@ -88,6 +88,9 @@ open class MusicService : MediaBrowserServiceCompat(), SessionAvailabilityListen
     protected lateinit var mediaController: MediaControllerCompat
     protected lateinit var mediaSessionConnector: MediaSessionConnector
 
+    // references either ExoPlayer or CastPlayer
+    private lateinit var currentPlayer: Player
+
     /**
      * This must be `by lazy` because the source won't initially be ready.
      * See [MusicService.onLoadChildren] to see where it's accessed (and first
@@ -197,11 +200,13 @@ open class MusicService : MediaBrowserServiceCompat(), SessionAvailabilityListen
                 dataSourceFactory
         )
         setPlayer(exoPlayer)
+        currentPlayer = exoPlayer
         setPlaybackPreparer(playbackPreparer)
     }
 
     private fun MediaSessionConnector.connectToCastPlayer() {
         setPlayer(castPlayer)
+        currentPlayer = castPlayer
         // removes preparer to make sure we don't preload local content while casting
         setPlaybackPreparer(null)
     }
@@ -221,8 +226,7 @@ open class MusicService : MediaBrowserServiceCompat(), SessionAvailabilityListen
          * be reported as [PlaybackStateCompat.STATE_NONE], the service will first remove
          * itself as a foreground service, and will then call [stopSelf].
          */
-        //exoPlayer.stop(true)
-        castPlayer.stop(true)
+        currentPlayer.stop(true)
     }
 
     override fun onDestroy() {

--- a/common/src/main/java/com/example/android/uamp/media/UampCastPlaybackPreparer.kt
+++ b/common/src/main/java/com/example/android/uamp/media/UampCastPlaybackPreparer.kt
@@ -1,0 +1,90 @@
+package com.example.android.uamp.media
+
+import android.net.Uri
+import android.os.Bundle
+import android.os.ResultReceiver
+import android.support.v4.media.MediaMetadataCompat
+import android.support.v4.media.session.MediaSessionCompat
+import android.support.v4.media.session.PlaybackStateCompat
+import android.util.Log
+import com.example.android.uamp.media.extensions.*
+import com.example.android.uamp.media.library.MusicSource
+import com.google.android.exoplayer2.C
+import com.google.android.exoplayer2.ControlDispatcher
+import com.google.android.exoplayer2.Player
+import com.google.android.exoplayer2.ext.cast.CastPlayer
+import com.google.android.exoplayer2.ext.mediasession.MediaSessionConnector
+import com.google.android.gms.cast.MediaQueueItem
+
+class UampCastPlaybackPreparer(
+        private val musicSource: MusicSource,
+        private val castPlayer: CastPlayer
+) : MediaSessionConnector.PlaybackPreparer {
+    override fun getSupportedPrepareActions(): Long =
+            PlaybackStateCompat.ACTION_PREPARE_FROM_MEDIA_ID or
+                    PlaybackStateCompat.ACTION_PLAY_FROM_MEDIA_ID
+
+    /**
+     * Handles callbacks to both [MediaSessionCompat.Callback.onPrepareFromMediaId]
+     * *AND* [MediaSessionCompat.Callback.onPlayFromMediaId] when using [MediaSessionConnector].
+     * This is done with the expectation that "play" is just "prepare" + "play".
+     */
+    override fun onPrepareFromMediaId(mediaId: String?, extras: Bundle?) {
+        musicSource.whenReady {
+            val itemToPlay: MediaMetadataCompat? = musicSource.find { item ->
+                item.id == mediaId
+            }
+            if (itemToPlay == null) {
+                Log.w(TAG, "Content not found: MediaID=$mediaId")
+
+                // TODO: Notify caller of the error.
+            } else {
+                val metadataList = buildPlaylist(itemToPlay)
+                val items: Array<MediaQueueItem> = metadataList.map {
+                    it.toMediaQueueItem()
+                }.toTypedArray()
+
+                // Since the playlist was probably based on some ordering (such as tracks
+                // on an album), find which window index to play first so that the song the
+                // user actually wants to hear plays first.
+                val initialWindowIndex = metadataList.indexOf(itemToPlay)
+
+                castPlayer.loadItems(items, initialWindowIndex, C.TIME_UNSET, Player.REPEAT_MODE_OFF)
+            }
+        }
+    }
+
+    override fun onPrepare() = Unit
+
+    /**
+     * Do not support callbacks to both [MediaSessionCompat.Callback.onPrepareFromSearch]
+     * *AND* [MediaSessionCompat.Callback.onPlayFromSearch] when using [MediaSessionConnector]
+     * with cast.
+     */
+    override fun onPrepareFromSearch(query: String?, extras: Bundle?)  = Unit
+
+    override fun onPrepareFromUri(uri: Uri?, extras: Bundle?) = Unit
+
+    override fun onCommand(
+            player: Player?,
+            controlDispatcher: ControlDispatcher?,
+            command: String?,
+            extras: Bundle?,
+            cb: ResultReceiver?
+    ) = false
+
+
+
+    /**
+     * Builds a playlist based on a [MediaMetadataCompat].
+     *
+     * TODO: Support building a playlist by artist, genre, etc...
+     *
+     * @param item Item to base the playlist on.
+     * @return a [List] of [MediaMetadataCompat] objects representing a playlist.
+     */
+    private fun buildPlaylist(item: MediaMetadataCompat): List<MediaMetadataCompat> =
+            musicSource.filter { it.album == item.album }.sortedBy { it.trackNumber }
+}
+
+private const val TAG = "CastPlaybackPreparer"

--- a/common/src/main/java/com/example/android/uamp/media/extensions/MediaMetadataCompatExt.kt
+++ b/common/src/main/java/com/example/android/uamp/media/extensions/MediaMetadataCompatExt.kt
@@ -25,6 +25,11 @@ import com.google.android.exoplayer2.source.ConcatenatingMediaSource
 import com.google.android.exoplayer2.source.ExtractorMediaSource
 import com.google.android.exoplayer2.source.ProgressiveMediaSource
 import com.google.android.exoplayer2.upstream.DataSource
+import com.google.android.exoplayer2.util.MimeTypes
+import com.google.android.gms.cast.MediaInfo
+import com.google.android.gms.cast.MediaMetadata
+import com.google.android.gms.cast.MediaQueueItem
+import com.google.android.gms.common.images.WebImage
 
 /**
  * Useful extensions for [MediaMetadataCompat].
@@ -180,6 +185,13 @@ inline var MediaMetadataCompat.Builder.mediaUri: String?
         putString(MediaMetadataCompat.METADATA_KEY_MEDIA_URI, value)
     }
 
+inline var MediaMetadataCompat.Builder.artUri: String?
+    @Deprecated(NO_GET, level = DeprecationLevel.ERROR)
+    get() = throw IllegalAccessException("Cannot get from MediaMetadataCompat.Builder")
+    set(value) {
+        putString(MediaMetadataCompat.METADATA_KEY_ART_URI, value)
+    }
+
 inline var MediaMetadataCompat.Builder.albumArtUri: String?
     @Deprecated(NO_GET, level = DeprecationLevel.ERROR)
     get() = throw IllegalAccessException("Cannot get from MediaMetadataCompat.Builder")
@@ -290,6 +302,33 @@ fun List<MediaMetadataCompat>.toMediaSource(
         concatenatingMediaSource.addMediaSource(it.toMediaSource(dataSourceFactory))
     }
     return concatenatingMediaSource
+}
+
+fun MediaMetadataCompat.toMediaQueueItem(): MediaQueueItem {
+    val metadata: MediaMetadata = toCastMediaMetadata()
+    val mediaInfo = MediaInfo.Builder(this.mediaUri.toString())
+            .setStreamType(MediaInfo.STREAM_TYPE_BUFFERED)
+            .setContentType(MimeTypes.AUDIO_MPEG)
+            .setStreamDuration(this.duration)
+            .setMetadata(metadata)
+            .build()
+    return MediaQueueItem.Builder(mediaInfo).build()
+}
+
+private fun MediaMetadataCompat.toCastMediaMetadata(): MediaMetadata {
+    val mediaMetadata = MediaMetadata(MediaMetadata.MEDIA_TYPE_MUSIC_TRACK)
+    mediaMetadata.putString(MediaMetadata.KEY_TITLE, this.title)
+    mediaMetadata.putString(MediaMetadata.KEY_ARTIST, this.artist)
+    mediaMetadata.putString(MediaMetadata.KEY_ALBUM_TITLE, this.album)
+    mediaMetadata.addImage(WebImage(this.artUri))
+    mediaMetadata.addImage(WebImage(this.albumArtUri))
+    mediaMetadata.addImage(WebImage(this.displayIconUri))
+    mediaMetadata.putString(MediaMetadata.KEY_ALBUM_ARTIST, this.albumArtist)
+    mediaMetadata.putString(MediaMetadata.KEY_COMPOSER, this.composer)
+    this.date?.let { date -> mediaMetadata.putString(MediaMetadata.KEY_RELEASE_DATE, date) }
+    mediaMetadata.putInt(MediaMetadata.KEY_TRACK_NUMBER, this.trackNumber.toInt())
+    mediaMetadata.putInt(MediaMetadata.KEY_DISC_NUMBER, this.discNumber.toInt())
+    return mediaMetadata
 }
 
 /**

--- a/common/src/main/java/com/example/android/uamp/media/library/JsonSource.kt
+++ b/common/src/main/java/com/example/android/uamp/media/library/JsonSource.kt
@@ -26,23 +26,7 @@ import com.bumptech.glide.RequestManager
 import com.bumptech.glide.load.engine.DiskCacheStrategy
 import com.bumptech.glide.request.RequestOptions
 import com.example.android.uamp.media.R
-import com.example.android.uamp.media.extensions.album
-import com.example.android.uamp.media.extensions.albumArtUri
-import com.example.android.uamp.media.extensions.artist
-import com.example.android.uamp.media.extensions.asAlbumArtContentUri
-import com.example.android.uamp.media.extensions.displayDescription
-import com.example.android.uamp.media.extensions.displayIconUri
-import com.example.android.uamp.media.extensions.displaySubtitle
-import com.example.android.uamp.media.extensions.displayTitle
-import com.example.android.uamp.media.extensions.downloadStatus
-import com.example.android.uamp.media.extensions.duration
-import com.example.android.uamp.media.extensions.flag
-import com.example.android.uamp.media.extensions.genre
-import com.example.android.uamp.media.extensions.id
-import com.example.android.uamp.media.extensions.mediaUri
-import com.example.android.uamp.media.extensions.title
-import com.example.android.uamp.media.extensions.trackCount
-import com.example.android.uamp.media.extensions.trackNumber
+import com.example.android.uamp.media.extensions.*
 import com.google.gson.Gson
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -159,6 +143,7 @@ fun MediaMetadataCompat.Builder.from(jsonMusic: JsonMusic): MediaMetadataCompat.
     duration = durationMs
     genre = jsonMusic.genre
     mediaUri = jsonMusic.source
+    artUri = jsonMusic.image // raw full-path URI to image, instead of Content Provider URI
     albumArtUri = jsonMusic.image
     trackNumber = jsonMusic.trackNumber
     trackCount = jsonMusic.totalTrackCount


### PR DESCRIPTION
Fixes https://github.com/android/uamp/issues/222

WIP.

Using ExoPlayer's [cast extension](https://medium.com/google-exoplayer/new-cast-extension-and-demo-app-55816a50012) and the default media receiver.

✔️ Discovering devices
✔️ Connecting to cast
✔️ Switching from Local (Exo) to Remote (Cast) and back

❌ Playback crashes after playing since `METADATA_KEY_MEDIA_ID` isn't present for cast, this `id` property can't be accessed for metadata update.

| Sender | Receiver |
| ------- | ------- |
| ![IMG_20200115_171904](https://user-images.githubusercontent.com/1541701/72468646-eb1bf700-37dd-11ea-9483-4724093f2c66.png) | ![IMG_20200115_171906](https://user-images.githubusercontent.com/1541701/72468664-f707b900-37dd-11ea-989d-ccae116b5e27.jpg) |