### PR TITLE
Migrate to ExoPlayer 2.11.5. Fixes #359

### DIFF
--- a/automotive/src/main/java/com/example/android/uamp/automotive/AutomotiveMusicService.kt
+++ b/automotive/src/main/java/com/example/android/uamp/automotive/AutomotiveMusicService.kt
@@ -134,9 +134,9 @@ class AutomotiveMusicService : MusicService() {
     private inner class AutomotiveCommandReceiver : CommandReceiver {
         @Suppress("PARAMETER_NAME_CHANGED_ON_OVERRIDE")
         override fun onCommand(
-            player: Player?,
-            controlDispatcher: ControlDispatcher?,
-            command: String?,
+            player: Player,
+            controlDispatcher: ControlDispatcher,
+            command: String,
             extras: Bundle?,
             callback: ResultReceiver?
         ): Boolean =

--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ buildscript {
         arch_lifecycle_version = '2.0.0'
         constraint_layout_version = '1.1.3'
         espresso_version = '3.1.1'
-        exoplayer_version = '2.10.0'
+        exoplayer_version = '2.11.5'
         glide_version = '4.11.0'
         gms_strict_version_matcher_version = '1.0.3'
         gradle_version = '3.1.4'

--- a/common/src/main/java/com/example/android/uamp/media/MusicService.kt
+++ b/common/src/main/java/com/example/android/uamp/media/MusicService.kt
@@ -18,17 +18,12 @@ package com.example.android.uamp.media
 
 import android.app.Notification
 import android.app.PendingIntent
-import android.content.BroadcastReceiver
-import android.content.Context
 import android.content.Intent
-import android.content.IntentFilter
-import android.media.AudioManager
 import android.net.Uri
 import android.os.Bundle
 import android.support.v4.media.MediaBrowserCompat
 import android.support.v4.media.MediaBrowserCompat.MediaItem
 import android.support.v4.media.MediaDescriptionCompat
-import android.support.v4.media.session.MediaControllerCompat
 import android.support.v4.media.session.MediaSessionCompat
 import androidx.core.content.ContextCompat
 import androidx.media.MediaBrowserServiceCompat
@@ -41,8 +36,8 @@ import com.example.android.uamp.media.library.UAMP_BROWSABLE_ROOT
 import com.example.android.uamp.media.library.UAMP_EMPTY_ROOT
 import com.google.android.exoplayer2.C
 import com.google.android.exoplayer2.ExoPlayer
-import com.google.android.exoplayer2.ExoPlayerFactory
 import com.google.android.exoplayer2.Player
+import com.google.android.exoplayer2.SimpleExoPlayer
 import com.google.android.exoplayer2.Timeline
 import com.google.android.exoplayer2.audio.AudioAttributes
 import com.google.android.exoplayer2.ext.mediasession.MediaSessionConnector
@@ -68,7 +63,7 @@ import kotlinx.coroutines.launch
  * visit [https://developer.android.com/guide/topics/media-apps/audio-app/building-a-mediabrowserservice.html](https://developer.android.com/guide/topics/media-apps/audio-app/building-a-mediabrowserservice.html).
  */
 open class MusicService : MediaBrowserServiceCompat() {
-    private lateinit var becomingNoisyReceiver: BecomingNoisyReceiver
+
     private lateinit var notificationManager: UampNotificationManager
     private lateinit var mediaSource: MusicSource
     private lateinit var packageValidator: PackageValidator
@@ -105,8 +100,9 @@ open class MusicService : MediaBrowserServiceCompat() {
      * See [Player.AudioComponent.setAudioAttributes] for details.
      */
     private val exoPlayer: ExoPlayer by lazy {
-        ExoPlayerFactory.newSimpleInstance(this).apply {
+        SimpleExoPlayer.Builder(this).build().apply {
             setAudioAttributes(uAmpAudioAttributes, true)
+            setHandleAudioBecomingNoisy(true)
             addListener(playerListener)
         }
     }
@@ -151,9 +147,6 @@ open class MusicService : MediaBrowserServiceCompat() {
             mediaSession.sessionToken,
             PlayerNotificationListener()
         )
-
-        becomingNoisyReceiver =
-            BecomingNoisyReceiver(context = this, sessionToken = mediaSession.sessionToken)
 
         // The media library is built from a remote JSON file. We'll create the source here,
         // and then use a suspend function to perform the download off the main thread.
@@ -324,7 +317,7 @@ open class MusicService : MediaBrowserServiceCompat() {
         PlayerNotificationManager.NotificationListener {
         override fun onNotificationPosted(
             notificationId: Int,
-            notification: Notification?,
+            notification: Notification,
             ongoing: Boolean
         ) {
             if (ongoing && !isForegroundService) {
@@ -354,7 +347,6 @@ open class MusicService : MediaBrowserServiceCompat() {
                 Player.STATE_BUFFERING,
                 Player.STATE_READY -> {
                     notificationManager.showNotification()
-                    becomingNoisyReceiver.register()
 
                     // If playback is paused we remove the foreground state which allows the
                     // notification to be dismissed. An alternative would be to provide a "close"
@@ -365,7 +357,6 @@ open class MusicService : MediaBrowserServiceCompat() {
                 }
                 else -> {
                     notificationManager.hideNotification()
-                    becomingNoisyReceiver.unregister()
                 }
             }
         }
@@ -382,42 +373,7 @@ private class UampQueueNavigator(
     private val window = Timeline.Window()
     override fun getMediaDescription(player: Player, windowIndex: Int): MediaDescriptionCompat =
         player.currentTimeline
-            .getWindow(windowIndex, window, true).tag as MediaDescriptionCompat
-}
-
-/**
- * Helper class for listening for when headphones are unplugged (or the audio
- * will otherwise cause playback to become "noisy").
- */
-private class BecomingNoisyReceiver(
-    private val context: Context,
-    sessionToken: MediaSessionCompat.Token
-) : BroadcastReceiver() {
-
-    private val noisyIntentFilter = IntentFilter(AudioManager.ACTION_AUDIO_BECOMING_NOISY)
-    private val controller = MediaControllerCompat(context, sessionToken)
-
-    private var registered = false
-
-    fun register() {
-        if (!registered) {
-            context.registerReceiver(this, noisyIntentFilter)
-            registered = true
-        }
-    }
-
-    fun unregister() {
-        if (registered) {
-            context.unregisterReceiver(this)
-            registered = false
-        }
-    }
-
-    override fun onReceive(context: Context, intent: Intent) {
-        if (intent.action == AudioManager.ACTION_AUDIO_BECOMING_NOISY) {
-            controller.transportControls.pause()
-        }
-    }
+            .getWindow(windowIndex, window).tag as MediaDescriptionCompat
 }
 
 /*

--- a/common/src/main/java/com/example/android/uamp/media/UampNotificationManager.kt
+++ b/common/src/main/java/com/example/android/uamp/media/UampNotificationManager.kt
@@ -16,17 +16,14 @@
 
 package com.example.android.uamp.media
 
-import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.app.PendingIntent
 import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.net.Uri
-import android.os.Build
 import android.support.v4.media.session.MediaControllerCompat
 import android.support.v4.media.session.MediaSessionCompat
-import androidx.annotation.RequiresApi
 import com.google.android.exoplayer2.ExoPlayer
 import com.google.android.exoplayer2.Player
 import com.google.android.exoplayer2.ui.PlayerNotificationManager
@@ -36,8 +33,8 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
-const val NOW_PLAYING_CHANNEL = "com.example.android.uamp.media.NOW_PLAYING"
-const val NOW_PLAYING_NOTIFICATION = 0xb339 // Arbitrary number used to identify our notification
+const val NOW_PLAYING_CHANNEL_ID = "com.example.android.uamp.media.NOW_PLAYING"
+const val NOW_PLAYING_NOTIFICATION_ID = 0xb339 // Arbitrary number used to identify our notification
 
 /**
  * A wrapper class for ExoPlayer's PlayerNotificationManager. It sets up the notification shown to
@@ -61,9 +58,10 @@ class UampNotificationManager(
 
         notificationManager = PlayerNotificationManager.createWithNotificationChannel(
             context,
-            NOW_PLAYING_CHANNEL,
+            NOW_PLAYING_CHANNEL_ID,
             R.string.notification_channel,
-            NOW_PLAYING_NOTIFICATION,
+            R.string.notification_channel_description,
+            NOW_PLAYING_NOTIFICATION_ID,
             DescriptionAdapter(mediaController),
             notificationListener
         ).apply {
@@ -91,18 +89,18 @@ class UampNotificationManager(
         var currentIconUri: Uri? = null
         var currentBitmap: Bitmap? = null
 
-        override fun createCurrentContentIntent(player: Player?): PendingIntent? =
+        override fun createCurrentContentIntent(player: Player): PendingIntent? =
             controller.sessionActivity
 
-        override fun getCurrentContentText(player: Player?) =
+        override fun getCurrentContentText(player: Player) =
             controller.metadata.description.subtitle.toString()
 
-        override fun getCurrentContentTitle(player: Player?) =
+        override fun getCurrentContentTitle(player: Player) =
             controller.metadata.description.title.toString()
 
         override fun getCurrentLargeIcon(
-            player: Player?,
-            callback: PlayerNotificationManager.BitmapCallback?
+            player: Player,
+            callback: PlayerNotificationManager.BitmapCallback
         ): Bitmap? {
             val iconUri = controller.metadata.description.iconUri
             return if (currentIconUri != iconUri || currentBitmap == null) {
@@ -114,7 +112,7 @@ class UampNotificationManager(
                     currentBitmap = iconUri?.let {
                         resolveUriAsBitmap(it)
                     }
-                    callback?.onBitmap(currentBitmap)
+                    currentBitmap?.let { callback.onBitmap(it) }
                 }
                 null
             } else {

--- a/common/src/main/java/com/example/android/uamp/media/extensions/MediaMetadataCompatExt.kt
+++ b/common/src/main/java/com/example/android/uamp/media/extensions/MediaMetadataCompatExt.kt
@@ -22,7 +22,6 @@ import android.support.v4.media.MediaBrowserCompat.MediaItem
 import android.support.v4.media.MediaDescriptionCompat
 import android.support.v4.media.MediaMetadataCompat
 import com.google.android.exoplayer2.source.ConcatenatingMediaSource
-import com.google.android.exoplayer2.source.ExtractorMediaSource
 import com.google.android.exoplayer2.source.ProgressiveMediaSource
 import com.google.android.exoplayer2.upstream.DataSource
 


### PR DESCRIPTION
Updating UAMP from ExoPlayer 2.10.0 to 2.11.5

**What are the changes?**
Blog post: https://medium.com/google-exoplayer/exoplayer-2-11-whats-new-e0e0701e4b6c
Relnotes: https://github.com/google/ExoPlayer/blob/release-v2/RELEASENOTES.md

**Changes which affect UAMP**
`setHandleAudioBecomingNoisy(true)`
Possibly: https://github.com/google/ExoPlayer/issues/6093
Possibly: https://github.com/google/ExoPlayer/issues/5891

**Issues**
Problem: MusicService.kt: (325, 9): 'onNotificationPosted' overrides nothing
Cause: Method signature changed from 

```
onNotificationPosted(
            notificationId: Int,
            notification: Notification?,
            ongoing: Boolean
        )
```

to

```
onNotificationPosted(
            notificationId: Int,
            notification: Notification,
            ongoing: Boolean
        )
```
Solution: Change Notification? to Notification

Problem: UampNotificationManager.kt: (88, 19): Class 'DescriptionAdapter' is not abstract and does not implement abstract member public abstract fun createCurrentContentIntent(p0: Player): PendingIntent? defined in com.google.android.exoplayer2.ui.PlayerNotificationManager.MediaDescriptionAdapter
Cause: Method signatures have changed
Solution: Update method signatures. See commit

Problem: MusicService.java:18: error: cannot find symbol
    private com.example.android.uamp.media.BecomingNoisyReceiver becomingNoisyReceiver;
                                          ^
Cause: Unknown - didn't investigate further because ExoPlayer can now handle the "becoming noisy" event for us. 
Solution: Remove class and add setHandleAudioBecomingNoisy(true) when SimpleExoPlayer is instantiated

Problem: MusicService.java:20: error: cannot find symbol
    private com.example.android.uamp.media.PackageValidator packageValidator;
Cause: The ctor sig is class PackageValidator(context: Context, @XmlRes xmlResId: Int) and the @XmlRes causes the build to fail
Solution: ?? clean and rebuild :/ 

Problem: UampPlaybackPreparer.kt: (41, 1): Class 'UampPlaybackPreparer' is not abstract and does not implement abstract member public abstract fun onPrepare(p0: Boolean): Unit defined in com.google.android.exoplayer2.ext.mediasession.MediaSessionConnector.PlaybackPreparer
Cause: method signature changes. E.g. onPrepareFromMediaId now supplies playWhenReady as a parameter
Solution: add the playWhenReady parameter to method signatures and pass this to exoPlayer where appropriate. Update comments. 

Problem: ExoPlayerFactory.newSimpleInstance is deprecated
Solution: 

```
SimpleExoPlayer.Builder(this).build().apply {
            setAudioAttributes(uAmpAudioAttributes, true)
            setHandleAudioBecomingNoisy(true)
            addListener(playerListener)
        }
```

Problem: PlayerNotificationManager.createWithNotificationChannel deprecated
Solution: Use the version which includes the channel description

Problem: .getWindow(windowIndex, window, true) deprecated
Solution: Change to .getWindow(windowIndex, window)