### PR TITLE
[WIP] Adding support for playback resumption

### DIFF
--- a/common/src/main/java/com/example/android/uamp/media/MusicService.kt
+++ b/common/src/main/java/com/example/android/uamp/media/MusicService.kt
@@ -312,9 +312,7 @@ open class MusicService : MediaBrowserServiceCompat() {
          * If the caller requests the recent root, return the most recently played song.
          */
         if (parentMediaId == UAMP_RECENT_ROOT) {
-            val recentSong = storage.loadRecentSong()
-            val recentSongList = if (recentSong != null) listOf(recentSong) else null
-            result.sendResult(recentSongList)
+            result.sendResult(storage.loadRecentSong()?.let { song -> listOf(song) })
         } else {
             // If the media source is ready, the results will be set synchronously here.
             val resultsSent = mediaSource.whenReady { successfullyInitialized ->
@@ -578,8 +576,9 @@ open class MusicService : MediaBrowserServiceCompat() {
                             // If playing, save the current media item in persistent
                             // storage so that playback can be resumed between device reboots.
                             // Search for "media resumption" for more information.
-                            storage.saveRecentSong(currentPlaylistItems[currentPlayer.currentWindowIndex].description)
-                            //storage.saveRecentMediaItemId(currentPlaylistItems[currentPlayer.currentWindowIndex].description.mediaId)
+                            serviceScope.launch{
+                                storage.saveRecentSong(currentPlaylistItems[currentPlayer.currentWindowIndex].description)
+                            }
                         } else {
                             // If playback is paused we remove the foreground state which allows the
                             // notification to be dismissed. An alternative would be to provide a

--- a/common/src/main/java/com/example/android/uamp/media/PersistentStorage.kt
+++ b/common/src/main/java/com/example/android/uamp/media/PersistentStorage.kt
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2020 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.android.uamp.media
+
+import android.content.Context
+import android.content.SharedPreferences
+import android.net.Uri
+import android.support.v4.media.MediaBrowserCompat
+import android.support.v4.media.MediaBrowserCompat.MediaItem.FLAG_PLAYABLE
+import android.support.v4.media.MediaDescriptionCompat
+
+class PersistentStorage private constructor(val context: Context) {
+
+    /**
+     * Store any data which must persist between restarts, such as the most recently played song
+     * , in shared preferences.
+     */
+    private var preferences: SharedPreferences = context.getSharedPreferences(
+        PREFERENCES_NAME,
+        Context.MODE_PRIVATE
+    )
+
+    companion object {
+
+        @Volatile
+        private var instance: PersistentStorage? = null
+
+        fun getInstance(context: Context) =
+            instance ?: synchronized(this) {
+                instance ?: PersistentStorage(context).also { instance = it }
+            }
+    }
+
+    fun saveRecentSong(description: MediaDescriptionCompat) {
+        preferences.edit()
+            .putString(RECENT_SONG_MEDIA_ID_KEY, description.mediaId)
+            .putString(RECENT_SONG_TITLE_KEY, description.title.toString())
+            .putString(RECENT_SONG_SUBTITLE_KEY, description.subtitle.toString())
+            .putString(RECENT_SONG_ICON_URI_KEY, description.iconUri.toString())
+            .apply()
+    }
+
+    fun loadRecentSong(): MediaBrowserCompat.MediaItem? {
+        val mediaId = preferences.getString(RECENT_SONG_MEDIA_ID_KEY, null)
+        return if (mediaId == null) {
+            null
+        } else {
+            MediaBrowserCompat.MediaItem(
+                MediaDescriptionCompat.Builder()
+                    .setMediaId(mediaId)
+                    .setTitle(preferences.getString(RECENT_SONG_TITLE_KEY, ""))
+                    .setSubtitle(preferences.getString(RECENT_SONG_SUBTITLE_KEY, ""))
+                    .setIconUri(Uri.parse(preferences.getString(RECENT_SONG_ICON_URI_KEY, "")))
+                    .build(), FLAG_PLAYABLE
+            )
+        }
+    }
+}
+
+private const val PREFERENCES_NAME = "uamp"
+private const val RECENT_SONG_MEDIA_ID_KEY = "recent_song_media_id"
+private const val RECENT_SONG_TITLE_KEY = "recent_song_title"
+private const val RECENT_SONG_SUBTITLE_KEY = "recent_song_subtitle"
+private const val RECENT_SONG_ICON_URI_KEY = "recent_song_icon_uri"

--- a/common/src/main/java/com/example/android/uamp/media/PersistentStorage.kt
+++ b/common/src/main/java/com/example/android/uamp/media/PersistentStorage.kt
@@ -19,6 +19,7 @@ package com.example.android.uamp.media
 import android.content.Context
 import android.content.SharedPreferences
 import android.net.Uri
+import android.os.Bundle
 import android.support.v4.media.MediaBrowserCompat
 import android.support.v4.media.MediaBrowserCompat.MediaItem.FLAG_PLAYABLE
 import android.support.v4.media.MediaDescriptionCompat
@@ -48,7 +49,8 @@ class PersistentStorage private constructor(val context: Context) {
             }
     }
 
-    suspend fun saveRecentSong(description: MediaDescriptionCompat) {
+    suspend fun saveRecentSong(description: MediaDescriptionCompat, position: Long) {
+
         withContext(Dispatchers.IO) {
 
             /**
@@ -66,6 +68,7 @@ class PersistentStorage private constructor(val context: Context) {
                 .putString(RECENT_SONG_TITLE_KEY, description.title.toString())
                 .putString(RECENT_SONG_SUBTITLE_KEY, description.subtitle.toString())
                 .putString(RECENT_SONG_ICON_URI_KEY, localIconUri.toString())
+                .putLong(RECENT_SONG_POSITION_KEY, position)
                 .apply()
         }
     }
@@ -75,12 +78,18 @@ class PersistentStorage private constructor(val context: Context) {
         return if (mediaId == null) {
             null
         } else {
+            val extras = Bundle().also {
+                val position = preferences.getLong(RECENT_SONG_POSITION_KEY, 0L)
+                it.putLong(MEDIA_DESCRIPTION_EXTRAS_START_PLAYBACK_POSITION_MS, position)
+            }
+
             MediaBrowserCompat.MediaItem(
                 MediaDescriptionCompat.Builder()
                     .setMediaId(mediaId)
                     .setTitle(preferences.getString(RECENT_SONG_TITLE_KEY, ""))
                     .setSubtitle(preferences.getString(RECENT_SONG_SUBTITLE_KEY, ""))
                     .setIconUri(Uri.parse(preferences.getString(RECENT_SONG_ICON_URI_KEY, "")))
+                    .setExtras(extras)
                     .build(), FLAG_PLAYABLE
             )
         }
@@ -92,3 +101,4 @@ private const val RECENT_SONG_MEDIA_ID_KEY = "recent_song_media_id"
 private const val RECENT_SONG_TITLE_KEY = "recent_song_title"
 private const val RECENT_SONG_SUBTITLE_KEY = "recent_song_subtitle"
 private const val RECENT_SONG_ICON_URI_KEY = "recent_song_icon_uri"
+private const val RECENT_SONG_POSITION_KEY = "recent_song_position"

--- a/common/src/main/java/com/example/android/uamp/media/UampNotificationManager.kt
+++ b/common/src/main/java/com/example/android/uamp/media/UampNotificationManager.kt
@@ -134,10 +134,10 @@ class UampNotificationManager(
     }
 }
 
-private const val NOTIFICATION_LARGE_ICON_SIZE = 144 // px
+const val NOTIFICATION_LARGE_ICON_SIZE = 144 // px
 
 private val glideOptions = RequestOptions()
     .fallback(R.drawable.default_art)
-    .diskCacheStrategy(DiskCacheStrategy.RESOURCE)
+    .diskCacheStrategy(DiskCacheStrategy.DATA)
 
 private const val MODE_READ_ONLY = "r"

--- a/common/src/main/java/com/example/android/uamp/media/extensions/MediaMetadataCompatExt.kt
+++ b/common/src/main/java/com/example/android/uamp/media/extensions/MediaMetadataCompatExt.kt
@@ -124,7 +124,6 @@ inline val MediaMetadataCompat.downloadStatus
  * Custom property for storing whether a [MediaMetadataCompat] item represents an
  * item that is [MediaItem.FLAG_BROWSABLE] or [MediaItem.FLAG_PLAYABLE].
  */
-@MediaItem.Flags
 inline val MediaMetadataCompat.flag
     get() = this.getLong(METADATA_KEY_UAMP_FLAGS).toInt()
 
@@ -251,7 +250,6 @@ inline var MediaMetadataCompat.Builder.downloadStatus: Long
  * Custom property for storing whether a [MediaMetadataCompat] item represents an
  * item that is [MediaItem.FLAG_BROWSABLE] or [MediaItem.FLAG_PLAYABLE].
  */
-@MediaItem.Flags
 inline var MediaMetadataCompat.Builder.flag: Int
     @Deprecated(NO_GET, level = DeprecationLevel.ERROR)
     get() = throw IllegalAccessException("Cannot get from MediaMetadataCompat.Builder")

--- a/common/src/main/java/com/example/android/uamp/media/library/BrowseTree.kt
+++ b/common/src/main/java/com/example/android/uamp/media/library/BrowseTree.kt
@@ -54,7 +54,11 @@ import com.example.android.uamp.media.extensions.urlEncoded
  *  `browseTree["Album_A"]` would return "Song_1" and "Song_2". Since those are leaf nodes,
  *  requesting `browseTree["Song_1"]` would return null (there aren't any children of it).
  */
-class BrowseTree(context: Context, musicSource: MusicSource) {
+class BrowseTree(
+    val context: Context,
+    musicSource: MusicSource,
+    val recentMediaId: String? = null
+) {
     private val mediaIdToChildren = mutableMapOf<String, MutableList<MediaMetadataCompat>>()
 
     /**
@@ -106,6 +110,11 @@ class BrowseTree(context: Context, musicSource: MusicSource) {
                 recommendedChildren += mediaItem
                 mediaIdToChildren[UAMP_RECOMMENDED_ROOT] = recommendedChildren
             }
+
+            // If this was recently played, add it to the recent root.
+            if (mediaItem.id == recentMediaId) {
+                mediaIdToChildren[UAMP_RECENT_ROOT] = mutableListOf(mediaItem)
+            }
         }
     }
 
@@ -147,6 +156,7 @@ const val UAMP_BROWSABLE_ROOT = "/"
 const val UAMP_EMPTY_ROOT = "@empty@"
 const val UAMP_RECOMMENDED_ROOT = "__RECOMMENDED__"
 const val UAMP_ALBUMS_ROOT = "__ALBUMS__"
+const val UAMP_RECENT_ROOT = "__RECENT__"
 
 const val MEDIA_SEARCH_SUPPORTED = "android.media.browse.SEARCH_SUPPORTED"
 

--- a/common/src/main/java/com/example/android/uamp/media/library/MusicSource.kt
+++ b/common/src/main/java/com/example/android/uamp/media/library/MusicSource.kt
@@ -34,7 +34,7 @@ import com.example.android.uamp.media.extensions.title
  * Interface used by [MusicService] for looking up [MediaMetadataCompat] objects.
  *
  * Because Kotlin provides methods such as [Iterable.find] and [Iterable.filter],
- * this is a convient interface to have on sources.
+ * this is a convenient interface to have on sources.
  */
 interface MusicSource : Iterable<MediaMetadataCompat> {
 


### PR DESCRIPTION
This PR adds support for Android 11's playback resumption feature. To test the feature: 

- Load UAMP on a device running Android 11 beta 3 or above. 
- Play a song
- Note that the media controls appear in the quick settings area
- Note the song position, then swipe the app away from recents to stop playback. On Android 10 this would dismiss the notification, however, on Android 11 the media controls will change to static controls showing the last played item
- Tap on the play icon in the media controls - the song should resume playing from the position it left off. 
- Now reboot your device. Media controls will be displayed for the recently played song. Again, tapping play will resume playback at the previous position.

Thanks to @SigmanZero and @nic0lette for their help with this. 