### PR TITLE
Add seamless transfer support

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -91,6 +91,8 @@
             </intent-filter>
         </service>
 
+        <receiver android:name="androidx.mediarouter.media.MediaTransferReceiver" />
+
     </application>
 
 </manifest>

--- a/app/src/main/java/com/example/android/uamp/MainActivity.kt
+++ b/app/src/main/java/com/example/android/uamp/MainActivity.kt
@@ -18,10 +18,15 @@ package com.example.android.uamp
 
 import android.media.AudioManager
 import android.os.Bundle
+import android.util.Log
 import android.view.Menu
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProviders
+import androidx.mediarouter.media.MediaControlIntent
+import androidx.mediarouter.media.MediaRouteSelector
+import androidx.mediarouter.media.MediaRouter
+import androidx.mediarouter.media.MediaRouterParams
 import com.example.android.uamp.fragments.MediaItemFragment
 import com.example.android.uamp.media.MusicService
 import com.example.android.uamp.utils.Event
@@ -29,12 +34,15 @@ import com.example.android.uamp.utils.InjectorUtils
 import com.example.android.uamp.viewmodels.MainActivityViewModel
 import com.google.android.gms.cast.framework.CastButtonFactory
 import com.google.android.gms.cast.framework.CastContext
-import com.google.android.gms.dynamite.DynamiteModule
+
 
 class MainActivity : AppCompatActivity() {
 
     private lateinit var viewModel: MainActivityViewModel
     private var castContext: CastContext? = null
+    private lateinit var selector: MediaRouteSelector
+    private lateinit var router: MediaRouter
+
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -44,6 +52,16 @@ class MainActivity : AppCompatActivity() {
         castContext = CastContext.getSharedInstance(this)
 
         setContentView(R.layout.activity_main)
+
+        router = MediaRouter.getInstance(this)
+        selector = MediaRouteSelector.Builder()
+            .addControlCategory(MediaControlIntent.CATEGORY_REMOTE_PLAYBACK)
+            .build()
+        router.routerParams = MediaRouterParams.Builder().setTransferToLocalEnabled(true).build()
+        router.addCallback(
+            selector, MediaRouterCallback(),
+            MediaRouter.CALLBACK_FLAG_REQUEST_DISCOVERY
+        )
 
         // Since UAMP is a music player, the volume controls should adjust the music volume while
         // in the app.
@@ -118,4 +136,20 @@ class MainActivity : AppCompatActivity() {
     private fun getBrowseFragment(mediaId: String): MediaItemFragment? {
         return supportFragmentManager.findFragmentByTag(mediaId) as MediaItemFragment?
     }
+
+    private inner class MediaRouterCallback : MediaRouter.Callback() {
+        override fun onRouteSelected(
+            router: MediaRouter,
+            route: MediaRouter.RouteInfo,
+            reason: Int
+        ) {
+            if (reason == MediaRouter.UNSELECT_REASON_ROUTE_CHANGED) {
+                Log.d(TAG, "Unselected because route changed, continue playback")
+            } else if (reason == MediaRouter.UNSELECT_REASON_STOPPED) {
+                Log.d(TAG, "Unselected because route was stopped, stop playback")
+            }
+        }
+    }
 }
+
+private const val TAG = "MainActivity"

--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ buildscript {
         androidx_car_version = '1.0.0-alpha7'
         androidx_core_ktx_version = '1.0.2'
         androidx_media_version = '1.0.1'
+        androidx_mediarouter_version = '1.2.0-alpha02'
         androidx_preference_version = '1.0.0'
         androidx_test_runner_version = '1.1.1'
         arch_lifecycle_version = '2.0.0'

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -51,6 +51,7 @@ dependencies {
     api "org.jetbrains.kotlinx:kotlinx-coroutines-android:$kotlin_coroutines_version"
 
     api "androidx.media:media:$androidx_media_version"
+    implementation "androidx.mediarouter:mediarouter:$androidx_mediarouter_version"
 
     api "com.google.code.gson:gson:$gson_version"
 

--- a/common/src/main/java/com/example/android/uamp/media/extensions/MediaMetadataCompatExt.kt
+++ b/common/src/main/java/com/example/android/uamp/media/extensions/MediaMetadataCompatExt.kt
@@ -124,7 +124,7 @@ inline val MediaMetadataCompat.downloadStatus
  * Custom property for storing whether a [MediaMetadataCompat] item represents an
  * item that is [MediaItem.FLAG_BROWSABLE] or [MediaItem.FLAG_PLAYABLE].
  */
-@MediaItem.Flags
+//@MediaItem.Flags
 inline val MediaMetadataCompat.flag
     get() = this.getLong(METADATA_KEY_UAMP_FLAGS).toInt()
 
@@ -251,7 +251,7 @@ inline var MediaMetadataCompat.Builder.downloadStatus: Long
  * Custom property for storing whether a [MediaMetadataCompat] item represents an
  * item that is [MediaItem.FLAG_BROWSABLE] or [MediaItem.FLAG_PLAYABLE].
  */
-@MediaItem.Flags
+//@MediaItem.Flags
 inline var MediaMetadataCompat.Builder.flag: Int
     @Deprecated(NO_GET, level = DeprecationLevel.ERROR)
     get() = throw IllegalAccessException("Cannot get from MediaMetadataCompat.Builder")


### PR DESCRIPTION
This PR adds support for seamless transfer. Currently it only supports the showing of remote routes in the output switcher. 

TODO: 

Figure out how to switch to the castPlayer and start playback when the route is changed through the output switcher. Here's what happens currently: 

- User taps on output switcher and chooses Cast device
- `MediaRouterCallback::onRouteSelected` is called

What really needs to happen now is `UampCastSessionAvailabilityListener::onCastSessionAvailable` needs to be called: https://github.com/android/uamp/blob/master/common/src/main/java/com/example/android/uamp/media/MusicService.kt#L412

