### PR TITLE
Fixed progress bar displays without network #400

### DIFF
--- a/app/src/main/java/com/example/android/uamp/fragments/MediaItemFragment.kt
+++ b/app/src/main/java/com/example/android/uamp/fragments/MediaItemFragment.kt
@@ -81,7 +81,12 @@ class MediaItemFragment : Fragment() {
             })
         mediaItemFragmentViewModel.networkError.observe(viewLifecycleOwner,
             Observer { error ->
-                binding.networkError.visibility = if (error) View.VISIBLE else View.GONE
+                if (error) {
+                    binding.loadingSpinner.visibility = View.GONE
+                    binding.networkError.visibility = View.VISIBLE
+                } else {
+                    binding.networkError.visibility = View.GONE
+                }
             })
 
         // Set the adapter


### PR DESCRIPTION
### Description
Issue link: https://github.com/android/uamp/issues/400

### Overview
Hide the progress bar when a network error observe was triggered.

![Screenshot 2020-10-04 at 20 57 53](https://user-images.githubusercontent.com/18151158/95025860-ec02fa80-0684-11eb-939c-91480b8fcc4b.png)

### Next
Of course, this fix only hides the progress bar when no connection, will be great in the future to add a retry logic in order to automatically load elements once the internet is again available 