### PR TITLE
Make ContentProvider block while downloading album art

### DIFF
--- a/app/src/main/java/com/example/android/uamp/MediaItemAdapter.kt
+++ b/app/src/main/java/com/example/android/uamp/MediaItemAdapter.kt
@@ -72,6 +72,7 @@ class MediaItemAdapter(
 
             Glide.with(holder.albumArt)
                 .load(mediaItem.albumArtUri)
+                .placeholder(R.drawable.default_art)
                 .into(holder.albumArt)
         }
     }

--- a/common/src/main/java/com/example/android/uamp/media/library/AlbumArtContentProvider.kt
+++ b/common/src/main/java/com/example/android/uamp/media/library/AlbumArtContentProvider.kt
@@ -25,6 +25,7 @@ import android.os.ParcelFileDescriptor
 import com.bumptech.glide.Glide
 import java.io.File
 import java.io.FileNotFoundException
+import java.util.concurrent.TimeUnit
 
 class AlbumArtContentProvider : ContentProvider() {
 
@@ -57,7 +58,7 @@ class AlbumArtContentProvider : ContentProvider() {
                 .asFile()
                 .load(remoteUri)
                 .submit()
-                .get()
+                .get(DOWNLOAD_TIMEOUT_SECONDS, TimeUnit.SECONDS)
 
             // Rename the file Glide created to match our own scheme.
             cacheFile.renameTo(file)
@@ -89,3 +90,5 @@ class AlbumArtContentProvider : ContentProvider() {
     override fun getType(uri: Uri): String? = null
 
 }
+
+const val DOWNLOAD_TIMEOUT_SECONDS = 30L

--- a/common/src/main/java/com/example/android/uamp/media/library/AlbumArtContentProvider.kt
+++ b/common/src/main/java/com/example/android/uamp/media/library/AlbumArtContentProvider.kt
@@ -27,6 +27,9 @@ import java.io.File
 import java.io.FileNotFoundException
 import java.util.concurrent.TimeUnit
 
+// The amount of time to wait for the album art file to download before timing out.
+const val DOWNLOAD_TIMEOUT_SECONDS = 30L
+
 class AlbumArtContentProvider : ContentProvider() {
 
     companion object {
@@ -90,5 +93,3 @@ class AlbumArtContentProvider : ContentProvider() {
     override fun getType(uri: Uri): String? = null
 
 }
-
-const val DOWNLOAD_TIMEOUT_SECONDS = 30L


### PR DESCRIPTION
By making `ContentProvider.openFile` block, rather than running it on a separate thread (coroutine) we pass the responsibility of creating a placeholder image whilst the album art is downloaded onto the client. 

This means that for the mobile app we can just use Glide's `placeholder` method to provide a temporary image (`R.drawable.default_art`) whilst one is downloaded. 

For the automotive app it does mean that the album art won't be displayed until it's downloaded - not ideal but I can't figure out any better way of doing this.  