### PR TITLE
Fix: keep `isForegroundService` flag in sync with service state

### DIFF
--- a/common/src/main/java/com/example/android/uamp/media/MusicService.kt
+++ b/common/src/main/java/com/example/android/uamp/media/MusicService.kt
@@ -618,6 +618,7 @@ open class MusicService : MediaBrowserServiceCompat() {
                             // "close" button in the notification which stops playback and clears
                             // the notification.
                             stopForeground(false)
+                            isForegroundService = false
                         }
                     }
                 }


### PR DESCRIPTION
This closes #444. 

The local flag `isForegroundService` is currently only set to `false` when the notification is cancelled:

https://github.com/android/uamp/blob/8dda0e8d3cb4ec9d4422fb40b02ea65bfd3f1b6c/common/src/main/java/com/example/android/uamp/media/MusicService.kt#L592-L596 

There is however another scenario that will stop the service from running in the foreground: when the player's playback state changes to paused (`playWhenReady == false`)

https://github.com/android/uamp/blob/8dda0e8d3cb4ec9d4422fb40b02ea65bfd3f1b6c/common/src/main/java/com/example/android/uamp/media/MusicService.kt#L615-L621

In this last scenario, `isForegroundService` is not set to `false`, which prevents it from being promoted to the foreground again when a notification update is posted:

https://github.com/android/uamp/blob/8dda0e8d3cb4ec9d4422fb40b02ea65bfd3f1b6c/common/src/main/java/com/example/android/uamp/media/MusicService.kt#L581-L590

This PR adds that missing statement, allowing the service to be promoted to the foreground again when playback resumes.

For a more extensive description of the bug, see issue description.