### PR TITLE
Setting package to null so notifications don't behave weird

### DIFF
--- a/common/src/main/java/com/example/android/uamp/media/MusicService.kt
+++ b/common/src/main/java/com/example/android/uamp/media/MusicService.kt
@@ -173,6 +173,7 @@ open class MusicService : MediaBrowserServiceCompat() {
         // Build a PendingIntent that can be used to launch the UI.
         val sessionActivityPendingIntent =
             packageManager?.getLaunchIntentForPackage(packageName)?.let { sessionIntent ->
+                sessionIntent.setPackage(null)
                 PendingIntent.getActivity(this, 0, sessionIntent, 0)
             }
 


### PR DESCRIPTION
The notifications of UAMP (for handheld phones) were behaving weirdly. If I started playing any song, minimized the app, and pressed the notification, it created a new Activity instance and added it to the back stack. This new activity showed the starting UI (where I could pick between "Recommended" and "Albums").

It shouldn't be doing that. Ideally, the app should open in the last screen I left off.

By adding `setPackage(null)` to the launcher intent obtained via `packageManager.getLaunchIntentForPackage(packageName)`, the behavior gets corrected. Now it always opens to the last screen where the user left off.

I am surprised this was the fix. The documentation of [`setPackage`](https://developer.android.com/reference/android/content/Intent#setPackage(java.lang.String)) doesn't give a hint as to why this happens.

I suspect this is a bug of the `getLaunchIntentForPackage(packageName)`.