### PR TITLE
Fixed potential ClassCastException

### DIFF
--- a/app/src/main/java/com/example/android/uamp/MainActivity.kt
+++ b/app/src/main/java/com/example/android/uamp/MainActivity.kt
@@ -112,6 +112,6 @@ class MainActivity : AppCompatActivity() {
     private fun isRootId(mediaId: String) = mediaId == viewModel.rootMediaId.value
 
     private fun getBrowseFragment(mediaId: String): MediaItemFragment? {
-        return supportFragmentManager.findFragmentByTag(mediaId) as MediaItemFragment?
+        return supportFragmentManager.findFragmentByTag(mediaId) as? MediaItemFragment
     }
 }


### PR DESCRIPTION
If a Fragment with a matching mediaId was not of type `MediaItemFragment`, rather than return null, the result would be a thrown `ClassCastException`.