### PR TITLE
Updated README to reflect minimum Android Studio version for View Binding Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ To get started with UAMP please read the [full guide](docs/FullGuide.md).
 Pre-requisites
 --------------
 
-- Android Studio 3.x
+- Android Studio 4.x
 
 Getting Started
 ---------------


### PR DESCRIPTION
The README currently specifies Android Studio 3.x as a pre-requisite for building the code, but this is no longer true due to the usage of View Binding.  Attempting to build the code on Android Studio 3.6.3 yields the following error:
```
FAILURE: Build failed with an exception.

* What went wrong:
This version of Android Studio cannot open this project, please retry with Android Studio 4.0 or newer.

* Try:
Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Exception is:
com.intellij.openapi.externalSystem.model.ExternalSystemException: This version of Android Studio cannot open this project, please retry with Android Studio 4.0 or newer.
```
Using Android Studio 4.0, the code successfully builds and runs.  I've updated the README to reflect this requirement.