### PR TITLE
Modernize build versions

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -17,7 +17,6 @@
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-kapt'
-apply plugin: 'kotlin-android-extensions'
 
 android {
     compileSdkVersion rootProject.compileSdkVersion
@@ -58,7 +57,7 @@ android {
 }
 
 dependencies {
-    implementation "com.android.support:multidex:$multidex_version"
+    implementation 'androidx.multidex:multidex:2.0.1'
 
     implementation project(':common')
 

--- a/app/src/main/java/com/example/android/uamp/viewmodels/MainActivityViewModel.kt
+++ b/app/src/main/java/com/example/android/uamp/viewmodels/MainActivityViewModel.kt
@@ -164,7 +164,7 @@ class MainActivityViewModel(
     ) : ViewModelProvider.NewInstanceFactory() {
 
         @Suppress("unchecked_cast")
-        override fun <T : ViewModel?> create(modelClass: Class<T>): T {
+        override fun <T : ViewModel> create(modelClass: Class<T>): T {
             return MainActivityViewModel(musicServiceConnection) as T
         }
     }

--- a/app/src/main/java/com/example/android/uamp/viewmodels/MediaItemFragmentViewModel.kt
+++ b/app/src/main/java/com/example/android/uamp/viewmodels/MediaItemFragmentViewModel.kt
@@ -174,7 +174,7 @@ class MediaItemFragmentViewModel(
     ) : ViewModelProvider.NewInstanceFactory() {
 
         @Suppress("unchecked_cast")
-        override fun <T : ViewModel?> create(modelClass: Class<T>): T {
+        override fun <T : ViewModel> create(modelClass: Class<T>): T {
             return MediaItemFragmentViewModel(mediaId, musicServiceConnection) as T
         }
     }

--- a/app/src/main/java/com/example/android/uamp/viewmodels/NowPlayingFragmentViewModel.kt
+++ b/app/src/main/java/com/example/android/uamp/viewmodels/NowPlayingFragmentViewModel.kt
@@ -194,7 +194,7 @@ class NowPlayingFragmentViewModel(
     ) : ViewModelProvider.NewInstanceFactory() {
 
         @Suppress("unchecked_cast")
-        override fun <T : ViewModel?> create(modelClass: Class<T>): T {
+        override fun <T : ViewModel> create(modelClass: Class<T>): T {
             return NowPlayingFragmentViewModel(app, musicServiceConnection) as T
         }
     }

--- a/automotive/build.gradle
+++ b/automotive/build.gradle
@@ -17,7 +17,6 @@
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-kapt'
-apply plugin: 'kotlin-android-extensions'
 
 android {
     compileSdkVersion rootProject.compileSdkVersion

--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@
 buildscript {
     ext {
         // App SDK versions.
-        compileSdkVersion = 30
+        compileSdkVersion = 33
         minSdkVersion = 19
         targetSdkVersion = 30
 
@@ -40,9 +40,8 @@ buildscript {
         gradle_version = '3.1.4'
         gson_version = '2.8.5'
         junit_version = '4.13'
-        kotlin_version = '1.3.72'
-        kotlin_coroutines_version = '1.1.0'
-        multidex_version = '1.0.3'
+        kotlin_version = '1.7.10'
+        kotlin_coroutines_version = '1.6.4'
         play_services_auth_version = '18.1.0'
         recycler_view_version = '1.1.0'
         robolectric_version = '4.2'
@@ -54,7 +53,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.0.1'
+        classpath 'com.android.tools.build:gradle:7.3.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "com.google.android.gms:strict-version-matcher-plugin:$gms_strict_version_matcher_version"
 

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -17,7 +17,6 @@
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-kapt'
-apply plugin: 'kotlin-android-extensions'
 
 android {
     compileSdkVersion rootProject.compileSdkVersion
@@ -53,6 +52,7 @@ dependencies {
     api "androidx.media:media:$androidx_media_version"
 
     api "com.google.code.gson:gson:$gson_version"
+    api "androidx.lifecycle:lifecycle-viewmodel-ktx:2.5.1"
 
     // ExoPlayer dependencies
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,7 +21,6 @@
 # http://www.gradle.org/docs/current/userguide/build_environment.html
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-android.enableJetifier=true
 android.useAndroidX=true
 org.gradle.jvmargs=-Xmx1536m
 # Required by Robolectric.

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-all.zip


### PR DESCRIPTION
Hit an issue with a too old version of gradle stopping it working in recent Android Studio.

Happy to close, but since I updated some build dependencies, thought it worth offering it up.  I understand if there are legacy reason why you don't want upgrades.