### PR TITLE
Use C.TIME_UNSET instead of -1 for unknown duration

### DIFF
--- a/common/src/main/java/com/example/android/uamp/media/library/JsonSource.kt
+++ b/common/src/main/java/com/example/android/uamp/media/library/JsonSource.kt
@@ -36,6 +36,7 @@ import com.example.android.uamp.media.extensions.mediaUri
 import com.example.android.uamp.media.extensions.title
 import com.example.android.uamp.media.extensions.trackCount
 import com.example.android.uamp.media.extensions.trackNumber
+import com.google.android.exoplayer2.C
 import com.google.gson.Gson
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -221,6 +222,6 @@ class JsonMusic {
     var image: String = ""
     var trackNumber: Long = 0
     var totalTrackCount: Long = 0
-    var duration: Long = -1
+    var duration: Long = C.TIME_UNSET
     var site: String = ""
 }


### PR DESCRIPTION
The javadoc for [`getDuration()`](https://developer.android.com/reference/androidx/media3/common/Player#getDuration()) in media3 `Player` says:

> Returns the duration of the current content or ad in milliseconds, or `TIME_UNSET` if the duration is not known.

In my understanding, negative values other than `TIME_UNSET` aren't valid (although we had to guard against them in e.g. google/horologist#728).