### PR TITLE
Fix media item conversion and align gradle versions with Media3

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -57,6 +57,7 @@ android {
 }
 
 dependencies {
+    coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.0.4")
     implementation "com.android.support:multidex:$multidex_version"
 
     implementation project(':common')

--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,6 @@ buildscript {
         robolectric_version = '4.11'
         test_runner_version = '1.1.0'
         agp_version = '8.0.1'
-        agp_version1 = '8.2.0'
     }
 
     repositories {
@@ -55,7 +54,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath "com.android.tools.build:gradle:$agp_version1"
+        classpath "com.android.tools.build:gradle:$agp_version"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "com.google.android.gms:strict-version-matcher-plugin:$gms_strict_version_matcher_version"
 

--- a/common/src/main/java/com/example/android/uamp/media/CastMediaItemConverter.kt
+++ b/common/src/main/java/com/example/android/uamp/media/CastMediaItemConverter.kt
@@ -71,7 +71,8 @@ internal class CastMediaItemConverter : MediaItemConverter {
             mediaInfo.setStreamDuration(bundle.getLong(MediaMetadataCompat.METADATA_KEY_DURATION,0))
         }
         mediaInfo.setMetadata(castMediaMetadata)
-        defaultMediaItemConverter.toMediaQueueItem(mediaItem).customData?.let {
+        val mediaQueueItem = defaultMediaItemConverter.toMediaQueueItem(mediaItem)
+        mediaQueueItem.media?.customData?.let {
             mediaInfo.setCustomData(it)
         }
         return MediaQueueItem.Builder(mediaInfo.build()).build()

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Jan 18 18:38:30 CET 2024
+#Fri Jan 19 12:47:52 CET 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
This change fixes a NullPointerException that was thrown when a 
MediaItem was attempted to be converted to a MediaQueueItem
when casting.

The other commit changes the gradle and gradle plugin version to
be the same as the Media3 project is using. This has the advantage,
that UAMP can be linked directly to the source code repository of
androidx/media as documented in
https://github.com/androidx/media?tab=readme-ov-file#locally.  