### PR TITLE
content/actions/hosting-your-own-runners/managing-self-hosted-runners/using-labels-with-self-hosted-runners.md

### DIFF
--- a/.google/packaging.yaml
+++ b/.google/packaging.yaml
@@ -1,11 +1,23 @@
-# GOOGLE SAMPLE PACKAGING DATA
+<manifest ...>
+    ...
+        <uses-feature
+                android:name="android.hardware.type.automotive"
+                        android:required="true" />
+                            ...
+                            </manifest># GOOGLE SAMPLE PACKAGING DATA
 #
 # This file is used by Google as part of our samples packaging process.
 # End users may safely ignore this file. It has no relevance to other systems.
 ---
 status:       PUBLISHED
 technologies: [Android, Android Auto, Android Automotive OS, Android Wear]
-categories:   [Getting Started, Media, UI]
+<manifest ...>
+    ...
+        <uses-feature
+                android:name="android.hardware.type.automotive"
+                        android:required="true" />
+                            ...
+                            </t>categories:   [Getting Started, Media, UI]
 languages:    [Kotlin]
 solutions:    [Mobile]
 


### PR DESCRIPTION
    ...
        <uses-feature
                android:name="android.hardware.type.automotive"
                        android:required="true" />
                            ...
                            </manifest>