### PR TITLE
Update Android workflow to use ubuntu-latest

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -25,7 +25,7 @@ jobs:
 
   build:
     name: Build
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v1


### PR DESCRIPTION
This commit updates the Android workflow file
`.github/workflows/android.yml` to use the `ubuntu-latest` runner image instead of `ubuntu-18.04`.